### PR TITLE
Packages: update requirements

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For more information, please visit [https://developers.hostinger.com](https://de
 
 ## Requirements.
 
-Python 3.9+
+Python 3.10+
 
 ## Installation & Usage
 ### pip install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,20 +10,21 @@ keywords = ["hostinger", "openapi", "python", "sdk", "rest", "api"]
 include = ["hostinger_api/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.7.0, < 3.0.0"
 python-dateutil = ">= 2.8.2"
 pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">= 7.2.1"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"
 types-python-dateutil = ">= 2.8.19.14"
 mypy = ">= 1.5"
+filelock = ">= 3.20.3"
 
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 1.25.3, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2
 typing-extensions >= 4.7.1

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ def read(filename):
 # http://pypi.python.org/pypi/setuptools
 NAME = "hostinger_api"
 VERSION = "0.0.22"
-PYTHON_REQUIRES = ">= 3.8"
+PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     url="https://github.com/hostinger/api-python-sdk",
     keywords=["hostinger", "openapi", "python", "sdk", "rest", "api"],
     install_requires=REQUIRES,
+    python_requires=PYTHON_REQUIRES,
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
     license="MIT",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
-pytest >= 7.2.1
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0
 types-python-dateutil >= 2.8.19.14
 mypy >= 1.5
+filelock >= 3.20.3


### PR DESCRIPTION
### Summary
Updates `urllib3`, `pytest`, and `filelock` to their latest secure releases to address known security advisories. All three target versions require **Python ≥ 3.10**, so this PR also drops support for Python 3.8 and 3.9.

### Dependency changes
- `urllib3`: `>= 1.25.3, < 3.0.0` → `>= 2.7.0, < 3.0.0` (runtime)
- `pytest`: `>= 7.2.1` → `>= 9.0.3` (dev/test)
- `filelock`: _(transitive, unpinned)_ → `>= 3.20.3` (dev/test)

### ⚠️ Breaking change: drops Python 3.8 / 3.9
The target versions all declare `requires-python >= 3.10`. There is no `urllib3 >= 2.7.0` build for 3.8/3.9, so keeping those versions would break `pip install`. Accordingly:
- `requires-python` bumped to `>= 3.10` (`pyproject.toml`, `setup.py`)
- CI matrix reduced to `[ "3.10", "3.11", "3.12" ]`
- README requirement updated to **Python 3.10+**

Consumers still on Python 3.8/3.9 must pin to a previous SDK release.

### Files changed
- `requirements.txt` — `urllib3` floor
- `setup.py` — `urllib3` floor + `PYTHON_REQUIRES`
- `pyproject.toml` — `urllib3` / `pytest` floors, added `filelock` dev dep, `python = "^3.10"`
- `test-requirements.txt` — `pytest` floor, added `filelock`
- `.github/workflows/build-release.yaml` — CI Python matrix
- `README.md` — supported Python version

### Notes
- `filelock` is a **test/build-only** dependency (transitive via tox/pytest), so it was added to the dev/test requirements only — not to the runtime `requirements.txt` / `setup.py`.
- `urllib3` retains its `< 3.0.0` upper bound; only the lower bound moved to exclude vulnerable releases.
- `setup.py` and `README.md` carry "auto-generated, DO NOT EDIT" banners (this repo is regenerated from the OpenAPI generator). These edits may need to be mirrored in the generator templates/config to survive the next `chore: sdk update`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Raised the project’s supported Python version to **3.10+**.
  * Updated dependency requirements, including a newer `urllib3` range.
  * Refreshed development and test tooling version constraints.

* **Tests**
  * Updated automated test runs to cover **Python 3.10, 3.11, and 3.12** only.

* **Documentation**
  * Revised the README requirements to match the new Python support policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->